### PR TITLE
fix _assemble_component

### DIFF
--- a/dataset/batch.py
+++ b/dataset/batch.py
@@ -578,7 +578,8 @@ class Batch(BaseBatch):
         except ValueError as e:
             message = str(e)
             if "must have the same shape" in message:
-                new_items = np.array(result, dtype=object)
+                new_items = np.empty(len(result), dtype=object)
+                new_items[:] = result
             else:
                 raise e
         setattr(self, component, new_items)


### PR DESCRIPTION
fix unexpected behavior in _assemble_component when results items has different shape but equal first dimension 
e.g., np.array([np.zeros((2, 2)), np.zeros((2,3))], dtype=object) fails, 
but np.array([np.zeros((2, 2)), np.zeros((3,3))], dtype=object) works fine.